### PR TITLE
Remove explicit wiki suffix from Lift Wing requests (eswikibooks and eswikiquote)

### DIFF
--- a/server.js
+++ b/server.js
@@ -369,7 +369,6 @@ function getModel(oresListModels, lwListModels, modelWiki, modelNamespace, lwIsA
         else return false;
     } else {
         let modelName = modelWiki;
-        if (!modelDomain.includes('.wikipedia.org') && !modelDomain.includes('wikidata.org')) modelName = modelWiki + 'wiki';
         if (oresListModels.damaging.includes(modelWiki)) return modelName + "-damaging" + "|" + modelName + "|" + "ORES";
         else if (oresListModels.reverted.includes(modelWiki)) return modelName + "-reverted" + "|" + modelName + "|" + "ORES";
         else return false;


### PR DESCRIPTION
After deploying a [change to better match Lift Wing wikiIds](https://phabricator.wikimedia.org/T342266) with those that exist in the configuration of mediawiki software we have made changed to the API Gateway. 
There changes affect the requests made to eswikibooks and eswikiquotes.
**So what actually changed In Lift Wing**
When making a request to eswikibooks or eswikiquote models on Lift Wing through the API Gateway, the `wiki` suffix should be removed.
**Old request**:
```
curl https://api.wikimedia.org/service/lw/inference/v1/models/eswikiquotewiki-goodfaith:predict -X POST -d '{"rev_id": 123}'
```
**New request**
```
curl https://api.wikimedia.org/service/lw/inference/v1/models/eswikiquote-goodfaith:predict -X POST -d '{"rev_id": 123}'
```
At the moment both can be accessed but once we remove the clients from the old ones we are going to remove these deployments.

**Changes in this PR**
Since all the wiki ids are defined in the exp.oresListModels variable exactly as they exist in the API gateway, explicitly appending the "wiki" suffix is no longer needed.
An alternative would be to add 2 more cases in the if statement about eswikiquote and eswikibooks. Feel free to keep whatever you believe is better.

**List of api gateway changes**

```
enwiktionarywiki-reverted -> enwiktionary-reverted
eswikiquotewiki-damaging -> eswikiquote-damaging
eswikiquotewiki-goodfaith -> eswikiquote-goodfaith
eswikibookswiki-damaging -> eswikibooks-damaging
eswikibookswiki-goodfaith -> eswikibooks-goodfaith
```